### PR TITLE
Fix axios error handling in frontend

### DIFF
--- a/frontend/src/utils/http.ts
+++ b/frontend/src/utils/http.ts
@@ -28,7 +28,9 @@ http.interceptors.response.use(
         return Promise.reject(new Error(msg));
     },
     err => {
-        if (err?.status === 401) {
+        const status = err?.response?.status;
+        const respData = err?.response?.data;
+        if (status === 401) {
             if (!isAuthModalShow) {
                 isAuthModalShow = true;
                 const modal = Modal.error({
@@ -49,10 +51,10 @@ http.interceptors.response.use(
                     window.location.href = '/login';
                 }, 2500);
             }
-        } else if (err?.status === 403) {
+        } else if (status === 403) {
             message.error('无权限操作');
         } else {
-            message.error(err?.data?.msg || err.message || '请求异常');
+            message.error(respData?.msg || err.message || '请求异常');
         }
         return Promise.reject(err);
     }


### PR DESCRIPTION
## Summary
- ensure axios interceptor inspects `response.status` for authorization errors

## Testing
- `npm run build -w frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f960b9ae48325bd7976d98f45e7ab