### PR TITLE
Add validation to auth routes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.0",
     "winston": "^3.17.0"
   },

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const bcrypt = require('bcryptjs')
 const jwt = require('jsonwebtoken')
+const { check, validationResult } = require('express-validator')
 const prisma = require('../utils/db')
 
 const router = express.Router()
@@ -8,9 +9,17 @@ const JWT_SECRET = process.env.JWT_SECRET
 const JWT_SESSION_DURATION= process.env.JWT_SESSION_DURATION || '2h'
 
 /** 注册 */
-router.post('/register', async (req, res) => {
+router.post('/register',
+  [
+    check('email').isEmail().withMessage('邮箱格式不正确'),
+    check('password').isLength({ min: 6 }).withMessage('密码长度至少6位'),
+  ],
+  async (req, res) => {
   const { email, password } = req.body
   if (!email || !password) return res.fail(400, '邮箱和密码为必填项')
+
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) return res.fail(400, errors.array()[0].msg)
 
   try {
     const exist = await prisma.user.findUnique({ where: { email } })
@@ -31,9 +40,17 @@ router.post('/register', async (req, res) => {
 })
 
 /** 登录 */
-router.post('/login', async (req, res) => {
+router.post('/login',
+  [
+    check('email').isEmail().withMessage('邮箱格式不正确'),
+    check('password').isLength({ min: 6 }).withMessage('密码长度至少6位'),
+  ],
+  async (req, res) => {
   const { email, password } = req.body
   if (!email || !password) return res.fail(400, '邮箱和密码为必填项')
+
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) return res.fail(400, errors.array()[0].msg)
 
   try {
     const user = await prisma.user.findUnique({ where: { email } })

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.0",
         "winston": "^3.17.0"
       },
@@ -2274,6 +2275,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz",
@@ -2754,8 +2768,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -4452,6 +4465,15 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {


### PR DESCRIPTION
## Summary
- add `express-validator` to backend dependencies
- validate email and password for auth routes

## Testing
- `npm run build -w backend`


------
https://chatgpt.com/codex/tasks/task_e_683fed40155c832593a8c3f9d5c6f28b