### PR TITLE
Fix ESLint parser options

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   env: { es2020: true },
+  parserOptions: { ecmaVersion: 2020 },
   extends: ['eslint:recommended', 'prettier'],
 };

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   extends: ['../.eslintrc.cjs', 'plugin:node/recommended'],
   env: { node: true },
+  parserOptions: { ecmaVersion: 2020 },
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "format": "prettier --write ."
   },
+  "engines": { "node": ">=16" },
   "dependencies": {
     "@prisma/client": "^4.8.0",
     "bcryptjs": "^3.0.2",


### PR DESCRIPTION
## Summary
- support ES2020 syntax by setting `ecmaVersion` in `.eslintrc.cjs`
- ensure eslint-plugin-node detects Node 16 by adding an `engines` field
- override parser options in backend ESLint config

## Testing
- `pnpm install`
- `pnpm lint` *(fails: no-unused-vars and no-process-exit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68415c32ccb48325a6c04ffdd9ee649b