### PR TITLE
Add todo search and filter

### DIFF
--- a/frontend/src/pages/TodoList.tsx
+++ b/frontend/src/pages/TodoList.tsx
@@ -6,6 +6,8 @@ import {
   List,
   Pagination,
   Space,
+  Input,
+  Select,
   Table,
   Popconfirm,
   message,
@@ -62,12 +64,21 @@ const ResponsiveTodoList: React.FC = () => {
   const [pageSize, setPageSize] = useState(10);
   const [total, setTotal] = useState<number>();
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
+  const [keyword, setKeyword] = useState('');
+  const [status, setStatus] = useState<'all' | 'done' | 'undone'>('all');
   const { logout } = useAuth();
 
-  const load = async (page = pageNum, size = pageSize) => {
+  const load = async (
+    page = pageNum,
+    size = pageSize,
+    kw = keyword,
+    s = status,
+  ) => {
     setLoading(true);
     try {
-      const { list, total } = await fetchTodos(page, size);
+      const doneParam =
+        s === 'all' ? undefined : s === 'done' ? 'true' : 'false';
+      const { list, total } = await fetchTodos(page, size, kw, doneParam);
       setTodos(list);
       setTotal(total);
     } catch (err: unknown) {
@@ -184,6 +195,31 @@ const ResponsiveTodoList: React.FC = () => {
         >
           新增
         </Button>
+        <Input.Search
+          allowClear
+          placeholder="搜索标题或描述"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onSearch={(v) => {
+            setPageNum(1);
+            load(1, pageSize, v, status);
+          }}
+          style={{ width: 200 }}
+        />
+        <Select
+          style={{ width: 120 }}
+          value={status}
+          onChange={(v) => {
+            setStatus(v);
+            setPageNum(1);
+            load(1, pageSize, keyword, v);
+          }}
+          options={[
+            { label: '全部', value: 'all' },
+            { label: '未完成', value: 'undone' },
+            { label: '已完成', value: 'done' },
+          ]}
+        />
         <Button icon={<LogoutOutlined />} onClick={logout}>
           退出
         </Button>

--- a/frontend/src/services/todo.ts
+++ b/frontend/src/services/todo.ts
@@ -6,9 +6,11 @@ import { BizResp, Todo, TodoListResp, TodoPayload } from '@/types';
 export const fetchTodos = async (
   pageNum = 1,
   pageSize = 10,
+  keyword?: string,
+  done?: string,
 ): Promise<TodoListResp> => {
   const res: BizResp<Todo[]> = await http.get('/todos/getPage', {
-    params: { pageNum, pageSize },
+    params: { pageNum, pageSize, keyword, done },
   });
 
   const { code, msg, data, count } = res;


### PR DESCRIPTION
## Summary
- support keyword and done query params when getting todo list
- filter todo list by title/description and done state
- allow searching and filtering in the todo list UI

## Testing
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68424ce4bba88325ad67473981b97271