### PR TITLE
Fix backend lint errors

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -2,4 +2,13 @@ module.exports = {
   extends: ['../.eslintrc.cjs', 'plugin:node/recommended'],
   env: { node: true },
   parserOptions: { ecmaVersion: 2020 },
+  overrides: [
+    {
+      files: ['tests/**/*.js'],
+      env: { jest: true },
+      rules: {
+        'node/no-unpublished-require': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- configure backend ESLint to recognize jest globals and ignore node/no-unpublished-require in tests

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847ee7e59448325a222a04a7ac1ff40